### PR TITLE
Update deploy workflow with `curl` and Node.js version bump

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -126,7 +126,7 @@ jobs:
       - uses: actions/checkout@v6
       - name: Get Runner IP
         id: ip
-        uses: haythem/public-ip@v1.3
+        run: echo "ipv4=$(curl -s https://checkip.amazonaws.com)" >> "$GITHUB_OUTPUT"
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v6
         with:
@@ -164,7 +164,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'yarn'
       - name: Install Yarn dependencies
         run: yarn install --frozen-lockfile --ignore-engines
@@ -257,7 +257,7 @@ jobs:
       - uses: actions/checkout@v6
       - name: Get Runner IP
         id: ip
-        uses: haythem/public-ip@v1.3
+        run: echo "ipv4=$(curl -s https://checkip.amazonaws.com)" >> "$GITHUB_OUTPUT"
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v6
         with:
@@ -295,7 +295,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'yarn'
       - name: Install Yarn dependencies
         run: yarn install --frozen-lockfile --ignore-engines


### PR DESCRIPTION
Updated the deployment workflow by replacing the `haythem/public-ip` GitHub action with a direct `curl` implementation to retrieve the public IP. Additionally, the Node.js version used in the workflow was upgraded to version 24 for compatibility and performance improvements.