### PR TITLE
Update deploy workflow configuration

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -143,7 +143,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.5'
+          php-version: '8.3'
           extensions: mbstring, xml, bcmath, ctype, json, tokenizer, pdo, pdo_mysql
       - name: Cache Composer packages
         id: composer-cache


### PR DESCRIPTION
- Downgraded production PHP version to 8.3 in the deploy workflow.  
- Replaced the `haythem/public-ip` GitHub Action with a `curl`-based approach for retrieving the public IP.  
- Updated Node.js version to 24 in the workflow configuration.  